### PR TITLE
Replaced 'browser' with 'main'

### DIFF
--- a/atom/browser/lib/init.coffee
+++ b/atom/browser/lib/init.coffee
@@ -38,7 +38,7 @@ process.on 'uncaughtException', (error) ->
   # Show error in GUI.
   stack = error.stack ? "#{error.name}: #{error.message}"
   message = "Uncaught Exception:\n#{stack}"
-  require('dialog').showErrorBox 'A JavaScript error occured in the browser process', message
+  require('dialog').showErrorBox 'A JavaScript error occured in the main process', message
 
 # Emit 'exit' event on quit.
 app = require 'app'


### PR DESCRIPTION
"A JavaScript error occured in the browser process" is confusing. Replacing it with 'main', just like everywhere else.
